### PR TITLE
feat: option to disable all cop blips for immersion

### DIFF
--- a/WarrantV/Scripts/Config.cs
+++ b/WarrantV/Scripts/Config.cs
@@ -58,6 +58,7 @@ namespace WarrantV
             public static bool WantedWhenMasked = true;
             public static bool OnlyPassangerCanCall = true;
             public static bool RecognitionScreenFX = true;
+            public static bool DisableAllCopBlips = false;
             public static bool PhoneBlipsEnabled = true;
             public static bool AlwaysShowPlate = false;
             public static bool CopBlipHeadingIndicator = true;
@@ -185,6 +186,7 @@ namespace WarrantV
                 "WantedWhenMasked = true",
                 "OnlyPassangerCanCall = true",
                 "RecognitionScreenFX = true",
+                "DisableAllCopBlips = false",
                 "PhoneBlipsEnabled = true",
                 "AlwaysShowPlate = false",
                 "CopBlipHeadingIndicator = true",
@@ -365,6 +367,7 @@ namespace WarrantV
             Config.Bools.WantedWhenMasked = ConfigFile.GetValue<bool>("FEATURES", "WantedWhenMasked", true);
             Config.Bools.OnlyPassangerCanCall = ConfigFile.GetValue<bool>("FEATURES", "OnlyPassangerCanCall", true);
             Config.Bools.RecognitionScreenFX = ConfigFile.GetValue<bool>("FEATURES", "RecognitionScreenFX", true);
+            Config.Bools.DisableAllCopBlips = ConfigFile.GetValue<bool>("FEATURES", "DisableAllCopBlips", false);
             Config.Bools.PhoneBlipsEnabled = ConfigFile.GetValue<bool>("FEATURES", "PhoneBlipsEnabled", true);
             Config.Bools.AlwaysShowPlate = ConfigFile.GetValue<bool>("FEATURES", "AlwaysShowPlate", false);
             Config.Bools.CopBlipHeadingIndicator = ConfigFile.GetValue<bool>("FEATURES", "CopBlipHeadingIndicator", true);

--- a/WarrantV/Scripts/EachTick.cs
+++ b/WarrantV/Scripts/EachTick.cs
@@ -26,10 +26,18 @@ namespace WarrantV
         {
             if (!Helpers.CopsList.Any(c => c.Item1 == cop))
             {
-                Helpers.CopsList.Add(new Tuple<Ped, Blip, float[], int[], Vector3>(cop, cop.AddBlip(), new float[2], new int[3], new Vector3()));
+                if (Config.Bools.DisableAllCopBlips)
+                {
+                    Helpers.CopsList.Add(new Tuple<Ped, Blip, float[], int[], Vector3>(cop, null, new float[2], new int[3], new Vector3()));
+                }
+                else
+                {
+                    Helpers.CopsList.Add(new Tuple<Ped, Blip, float[], int[], Vector3>(cop, cop.AddBlip(), new float[2], new int[3], new Vector3()));
+                }
             }
             int Index = Helpers.CopsList.FindIndex(c => c.Item1 == cop);
-            Blip CopBlip = Helpers.CopsList[Index].Item2;
+            Blip CopBlip = null;
+            if (!Config.Bools.DisableAllCopBlips) { CopBlip = Helpers.CopsList[Index].Item2; }
             float[] Recognition = new float[] { Helpers.CopsList[Index].Item3[0], Helpers.CopsList[Index].Item3[1] };
             int LastSeen = Helpers.CopsList[Index].Item4[0];
             int CallDelay = Helpers.CopsList[Index].Item4[1];

--- a/WarrantV/Scripts/Helpers.cs
+++ b/WarrantV/Scripts/Helpers.cs
@@ -228,61 +228,77 @@ namespace WarrantV
         public static int BlipHandle(Ped cop, Blip blip, float[] Recog, int TaskType, Vector3 LastSeen, bool PlayerVisible)
         {
             int ReturnTaskType = TaskType;
-            blip.Scale = Config.Numeric.CopBlipScale;
-            blip.Priority = 10;
-            blip.IsShortRange = false;
-            blip.ShowsCrewIndicator = false;
-            blip.ShowsFriendIndicator = false;
-            switch(PlayerID())
+
+            if (blip != null)
             {
-                case 0:
-                    blip.SecondaryColor = Color.FromArgb(255, 109,184,215);
-                    break;
-                case 1:
-                    blip.SecondaryColor = Color.FromArgb(255, 176,238,175);
-                    break;
-                case 2:
-                    blip.SecondaryColor = Color.FromArgb(255,255,167,95);
-                    break;
-                default:
-                    blip.SecondaryColor = Color.White;
-                    break;
-            }
-            if (CopState(cop) == Config.Strings.CopStateHeli)
-            {
-                if (blip.Sprite != BlipSprite.HelicopterAnimated) blip.Sprite = BlipSprite.HelicopterAnimated;
-                Function.Call(Hash.SHOW_HEADING_INDICATOR_ON_BLIP, blip, false);
-            }
-            else
-            {
-                blip.Sprite = (BlipSprite)1;
-                bool EnableCone = ((Config.Bools.CopBlipCone && !Config.Bools.CopBlipOnlyWhenInvisible) || (Config.Bools.CopBlipCone && Config.Bools.CopBlipOnlyWhenInvisible && !Helpers.IsPlayerVisible()));
-                Function.Call(Hash.SHOW_HEADING_INDICATOR_ON_BLIP, blip, Config.Bools.CopBlipHeadingIndicator);
-                Function.Call(Hash.SET_BLIP_SHOW_CONE, blip, EnableCone, 11);
-            }
-            if ((cop.IsDead || !cop.Exists()) && cop.AttachedBlip != null) { blip.Delete(); return 0; }
-            if (cop.IsInVehicle())
-            {
-                if ((cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Driver) == cop && cop.IsAlive) && !cop.CurrentVehicle.IsSeatFree(VehicleSeat.Passenger))
+                blip.Scale = Config.Numeric.CopBlipScale;
+                blip.Priority = 10;
+                blip.IsShortRange = false;
+                blip.ShowsCrewIndicator = false;
+                blip.ShowsFriendIndicator = false;
+                switch(PlayerID())
                 {
-                    if (CopsList.Any(c => c.Item1 == cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Passenger)))
+                    case 0:
+                        blip.SecondaryColor = Color.FromArgb(255, 109,184,215);
+                        break;
+                    case 1:
+                        blip.SecondaryColor = Color.FromArgb(255, 176,238,175);
+                        break;
+                    case 2:
+                        blip.SecondaryColor = Color.FromArgb(255,255,167,95);
+                        break;
+                    default:
+                        blip.SecondaryColor = Color.White;
+                        break;
+                }
+                
+                if (CopState(cop) == Config.Strings.CopStateHeli)
+                {
+                    if (blip.Sprite != BlipSprite.HelicopterAnimated) blip.Sprite = BlipSprite.HelicopterAnimated;
+                    Function.Call(Hash.SHOW_HEADING_INDICATOR_ON_BLIP, blip, false);
+                }
+                else
+                {
+                    blip.Sprite = (BlipSprite)1;
+                    bool EnableCone = ((Config.Bools.CopBlipCone && !Config.Bools.CopBlipOnlyWhenInvisible) || (Config.Bools.CopBlipCone && Config.Bools.CopBlipOnlyWhenInvisible && !Helpers.IsPlayerVisible()));
+                    Function.Call(Hash.SHOW_HEADING_INDICATOR_ON_BLIP, blip, Config.Bools.CopBlipHeadingIndicator);
+                    Function.Call(Hash.SET_BLIP_SHOW_CONE, blip, EnableCone, 11);
+                }
+                
+                if ((cop.IsDead || !cop.Exists()) && cop.AttachedBlip != null) { blip.Delete(); return 0; }
+                
+                if (cop.IsInVehicle())
+                {
+                    if ((cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Driver) == cop && cop.IsAlive) && !cop.CurrentVehicle.IsSeatFree(VehicleSeat.Passenger))
                     {
-                        int Index = CopsList.FindIndex(c => c.Item1 == cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Passenger));
-                        if (CopsList[Index].Item3[0] > Recog[0]) Recog[0] = CopsList[Index].Item3[0];
-                        if (CopsList[Index].Item3[1] > Recog[1]) Recog[1] = CopsList[Index].Item3[1];
+                        if (CopsList.Any(c => c.Item1 == cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Passenger)))
+                        {
+                            int Index = CopsList.FindIndex(c => c.Item1 == cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Passenger));
+                            if (CopsList[Index].Item3[0] > Recog[0]) Recog[0] = CopsList[Index].Item3[0];
+                            if (CopsList[Index].Item3[1] > Recog[1]) Recog[1] = CopsList[Index].Item3[1];
+                        }
                     }
+                    if (cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Driver) != cop && !cop.CurrentVehicle.IsSeatFree(VehicleSeat.Driver) || Config.Bools.DisableAllCopBlips)
+                    {
+                        blip.Alpha = 0;
+                    }
+                    
+                    blip.Scale = Config.Numeric.CopBlipVehScale;
                 }
-                if (cop.CurrentVehicle.GetPedOnSeat(VehicleSeat.Driver) != cop && !cop.CurrentVehicle.IsSeatFree(VehicleSeat.Driver))
-                {
-                    blip.Alpha = 0;
-                }
-                blip.Scale = Config.Numeric.CopBlipVehScale;
+                else blip.Alpha = 255;
+                
+                blip.Name = $"{CopState(cop)} {CopRecogState(cop, Recog)}";
+                
             }
-            else blip.Alpha = 255;
-            blip.Name = $"{CopState(cop)} {CopRecogState(cop, Recog)}";
+            
+            
             if (Recog[0] <= 20 || Recog[1] <= 20)
             {
-                blip.Color = BlipColor.Green;
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    blip.Color = BlipColor.Green;
+                }
+                    
                 if (Game.Player.WantedLevel == 0 && TaskType == 0 && PlayerVisible && Config.Bools.CopsDoTasks)
                 {
                     cop.Task.LookAt(Game.Player.Character, 300);
@@ -290,8 +306,12 @@ namespace WarrantV
             }
             if (Recog[0] > 20 || Recog[1] > 20)
             {
-                blip.Color = BlipColor.GreenDark;
-                blip.Priority = 11;
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    blip.Color = BlipColor.GreenDark;
+                    blip.Priority = 11;
+                }
+                
                 if (Game.Player.WantedLevel == 0 && !cop.IsInVehicle() && TaskType == 0 && PlayerVisible && Config.Bools.CopsDoTasks)
                 {
                     cop.Task.LookAt(Game.Player.Character, 300);
@@ -299,8 +319,12 @@ namespace WarrantV
             }
             if (Recog[0] > 40 || Recog[1] > 40)
             {
-                blip.Color = BlipColor.Yellow;
-                blip.Priority = 12;
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    blip.Color = BlipColor.Yellow;
+                    blip.Priority = 12;
+                }
+                
                 if (Game.Player.WantedLevel == 0 && !cop.IsInVehicle() && TaskType == 0 && PlayerVisible && Config.Bools.CopsDoTasks)
                 {
                     cop.Task.TurnTo(Game.Player.Character, 100);
@@ -316,8 +340,12 @@ namespace WarrantV
             }
             if (Recog[0] > 60 || Recog[1] > 60)
             {
-                blip.Color = BlipColor.Orange;
-                blip.Priority = 13;
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    blip.Color = BlipColor.Orange;
+                    blip.Priority = 13;
+                }
+                
                 if (TaskType <= 1 && Game.Player.WantedLevel == 0 && Config.Bools.CopsDoTasks)
                 {
                     if (!cop.IsInVehicle())
@@ -333,8 +361,12 @@ namespace WarrantV
             }
             if (Recog[0] > 80 || Recog[1] > 80)
             {
-                blip.Color = BlipColor.Red;
-                blip.Priority = 14;
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    blip.Color = BlipColor.Red;
+                    blip.Priority = 14;
+                }
+                
                 if (TaskType <= 2 && Game.Player.WantedLevel == 0 && Config.Bools.CopsDoTasks)
                 {
                     if (!cop.IsInVehicle()) 
@@ -374,12 +406,17 @@ namespace WarrantV
             if (Recog[0] >= 100 || Recog[1] >= 100)
             {
                 ReturnTaskType = 4;
-                blip.Color = BlipColor.RedDark;
-                blip.Priority = 15;
-                if (Config.Bools.ExtraBlipIndicators)
+                
+                if (!Config.Bools.DisableAllCopBlips)
                 {
-                    if (Recog[0] >= 100) blip.ShowsCrewIndicator = true;
-                    if (Recog[1] >= 100) blip.ShowsFriendIndicator = true;
+                    blip.Color = BlipColor.RedDark;
+                    blip.Priority = 15;
+                    
+                    if (Config.Bools.ExtraBlipIndicators)
+                    {
+                        if (Recog[0] >= 100) blip.ShowsCrewIndicator = true;
+                        if (Recog[1] >= 100) blip.ShowsFriendIndicator = true;
+                    }
                 }
             }
             return ReturnTaskType;
@@ -689,7 +726,10 @@ namespace WarrantV
             {
                 foreach (Tuple<Ped, Blip, float[], int[], Vector3> CopsList in Helpers.CopsList)
                 {
-                    CopsList.Item2.Delete();
+                    if (!Config.Bools.DisableAllCopBlips)
+                    {
+                        CopsList.Item2.Delete();
+                    }
                 }
                 Helpers.CopsList = new List<Tuple<Ped, Blip, float[], int[], Vector3>>();
             }

--- a/WarrantV/Scripts/Main.cs
+++ b/WarrantV/Scripts/Main.cs
@@ -150,9 +150,12 @@ namespace WarrantV
                 Even = !Even;
                 Game.Player.Character.CanWearHelmet = !Helpers.Masked().Item2;
                 if (Config.Strings.PhoneUse.Contains("ERROR")) Config.Read();
-                foreach (Tuple<Ped, Blip, float[], int[], Vector3> CopInList in Helpers.CopsList)
+                if (!Config.Bools.DisableAllCopBlips)
                 {
-                    if (CopInList.Item1.IsDead || !CopInList.Item1.Exists()) CopInList.Item2.Delete();
+                    foreach (Tuple<Ped, Blip, float[], int[], Vector3> CopInList in Helpers.CopsList)
+                    {
+                        if (CopInList.Item1.IsDead || !CopInList.Item1.Exists()) CopInList.Item2.Delete();
+                    }
                 }
                 if (Function.Call<bool>(Hash.IS_PLAYER_SWITCH_IN_PROGRESS))
                 {
@@ -333,7 +336,10 @@ namespace WarrantV
             if (Config.Bools.CrashAndEnterMessage) Notification.PostTicker("Press F to WarrantsV, it crashed", true);
             foreach (Tuple<Ped, Blip, float[], int[], Vector3> CopsList in Helpers.CopsList)
             {
-                CopsList.Item2.Delete();
+                if (!Config.Bools.DisableAllCopBlips)
+                {
+                    CopsList.Item2.Delete();
+                }
             }
             EachTick.LastCopsPositionBlip.Delete();
             EachTick.ChoiceMenus.ClosestPhoneBoothBlip.Delete();


### PR DESCRIPTION
- If DisableAllCopBlips is enabled, cop blips will never show, even if you're being recognised
- Does not interfere with stock game wanted cop blips (the ones which flash blue/red)
- Unfortunately, to ensure this, I had to make the CopBlip null when collating CopsList (EachTick.cs:29)
- Simply setting blip alpha to 0 would randomly affect the game's stock cop blips too.
- This behaviour is hardcoded into GTA 5, as the root cause was cop.AddBlip() when collating CopsList, which simply calls the ADD_BLIP_FOR_ENTITY native - this seemingly replaces the built in "wanted" flashing cop blips
- A solution that avoids the introduction of nulls would require significant refactoring of the codebase in an OOP form
- Despite this, I've implemented plenty of checks to ensure the script remains stable

***

- I would've loved to implement the additional option "AlwaysShowRecognitionBlips", to always show "recognition" blips (dark green > orange > red > dark red).
- This would be great for keeping the scripts functionality visible but not interfering with the base game experience.
- However it doesn't seem that its possible without significant refactoring.

***

- Options that needs to be manually added to existing ini files: 

`DisableAllCopBlips = false`
under
`RecognitionScreenFX = true`

***

- Tested and working on GTA 5 3411 with SHVDN Nightly 20